### PR TITLE
fix(gps): Marker & Polyline support (fix #10)

### DIFF
--- a/Backend GAS/Code.js
+++ b/Backend GAS/Code.js
@@ -48,7 +48,7 @@ function doGet(e) {
                 return sendSuccess(getGpsMarker(params.device_id));
 
             case 'sensor/gps/polyline':
-                return sendSuccess(getGpsPolyline(params.device_id, params.from, params.to));
+                return sendSuccess(getGpsPolyline(params.device_id, params.from, params.to, params.limit));
 
             case 'ui':
                 return HtmlService.createHtmlOutputFromFile('Index')
@@ -446,7 +446,7 @@ function getGpsMarker(deviceId) {
                 device_id: deviceId,
                 lat: data[i][1],
                 lng: data[i][2],
-                accuracy: data[i][3],
+                accuracy_m: data[i][3],
                 altitude: data[i][4],
                 ts: data[i][5],
             };
@@ -471,7 +471,7 @@ function getGpsMarker(deviceId) {
  * @param {string} to   - ISO-8601 datetime
  * @returns {Object}
  */
-function getGpsPolyline(deviceId, from, to) {
+function getGpsPolyline(deviceId, from, to, limit) {
     if (!deviceId) {
         throw new Error('Missing required parameter: device_id');
     }
@@ -495,19 +495,23 @@ function getGpsPolyline(deviceId, from, to) {
             points.push({
                 lat: data[i][1],
                 lng: data[i][2],
-                accuracy: data[i][3],
+                accuracy_m: data[i][3],
                 altitude: data[i][4],
                 ts: data[i][5],
             });
         }
     }
 
+    // Apply limit (return last N points) if provided
+    const nLimit = limit ? parseInt(limit, 10) : null;
+    const items = (nLimit && points.length > nLimit) ? points.slice(points.length - nLimit) : points;
+
     return {
         device_id: deviceId,
         from: startTime.toISOString(),
         to: endTime.toISOString(),
-        count: points.length,
-        points: points,
+        count: items.length,
+        items: items,
     };
 }
 

--- a/Backend GAS/openapi.yaml
+++ b/Backend GAS/openapi.yaml
@@ -67,6 +67,12 @@ paths:
             type: string
             format: date-time
           description: ISO-8601 start time (path=sensor/gps/polyline, default last 24h)
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+          description: Maximum number of history points to return (path=sensor/gps/polyline)
         - name: to
           in: query
           schema:
@@ -97,7 +103,7 @@ paths:
                       device_id: "dev-001"
                       lat: -7.983908
                       lng: 112.621391
-                      accuracy: 5.0
+                      accuracy_m: 5.0
                       altitude: 450.0
                       ts: "2026-02-18T10:00:00Z"
                 gpsPolyline:
@@ -109,15 +115,15 @@ paths:
                       from: "2026-02-17T10:00:00.000Z"
                       to: "2026-02-18T10:00:00.000Z"
                       count: 2
-                      points:
+                      items:
                         - lat: -7.983908
                           lng: 112.621391
-                          accuracy: 5
+                          accuracy_m: 5
                           altitude: 450
                           ts: "2026-02-18T07:00:00Z"
                         - lat: -7.984000
                           lng: 112.622000
-                          accuracy: 4
+                          accuracy_m: 4
                           altitude: 451
                           ts: "2026-02-18T08:00:00Z"
                 apiInfo:
@@ -315,7 +321,7 @@ components:
           type: number
           format: double
           example: 112.621391
-        accuracy:
+        accuracy_m:
           type: number
           example: 5.0
         altitude:


### PR DESCRIPTION
Implement GPS API improvements: return accuracy_m, add 'limit' param for history and return 'items' array.\n\nCloses #10